### PR TITLE
cro3.bash: Fix to add a space before closing brace

### DIFF
--- a/src/cmd/cro3.bash
+++ b/src/cmd/cro3.bash
@@ -165,7 +165,7 @@ _cro3() { # command current prev
   elif [ x"$prev" = x"--board" ]; then
     local BOARDS=`_cro3_get_boards`
     COMPREPLY=($(compgen -W "${BOARDS}" -- $cur))
-  elif [ x"$prev" = x"--branch"]; then 
+  elif [ x"$prev" = x"--branch" ]; then
     local BRANCHES=`_cro3_get_branches`
     COMPREPLY=($(compgen -W "${BRANCHES}" -- $cur))
   elif _cro3_arg_included ${prev} ${servo_serial_opts}; then


### PR DESCRIPTION
Fix an error message by adding a space before `]` (closing brace).