### PR TITLE
Replace fn_args_layout to fn_params_layout as the warning says

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 tab_spaces = 4
-fn_args_layout = "Tall"
+fn_params_layout = "Tall"
 format_strings = true
 use_try_shorthand = true
 wrap_comments = true


### PR DESCRIPTION
To supress the warning message on cargo fmt

TEST=make check