### PR TITLE
tast: build: Remove update_chroot

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -33,7 +33,7 @@ pub struct Args {
     #[argh(positional)]
     packages: Vec<String>,
 
-    /// if specified, skip update_chroot and setup_board
+    /// if specified, skip setup_board
     #[argh(switch)]
     skip_setup: bool,
 
@@ -66,7 +66,6 @@ pub fn run(args: &Args) -> Result<()> {
             &format!(
                 r###"
 setup_board --force --board={board}
-update_chroot
 "###,
             ),
             None,

--- a/src/cmd/tast.rs
+++ b/src/cmd/tast.rs
@@ -110,9 +110,6 @@ fn update_cached_tests(bundles: &Vec<&str>, dut: &str, repodir: &str) -> Result<
     let ssh = SshInfo::new(dut).context("failed to create SshInfo")?;
     let ssh = ssh.into_forwarded()?;
 
-    // To avoid "build failed: failed checking build deps:" error
-    chroot.run_bash_script_in_chroot("update_board_chroot", "update_chroot", None)?;
-
     for b in bundles {
         update_cached_tests_in_bundle(b, &chroot, ssh.port())?
     }


### PR DESCRIPTION
Remove update_chroot from `tast list` and `build` commands because it is not required anymore.