### PR TITLE
cro3.bash: Handle if there are short and long options

### DIFF
--- a/scripts/bash_completion_check.sh
+++ b/scripts/bash_completion_check.sh
@@ -12,8 +12,9 @@ Usage: cro3 [options]
 dummy cro3 for test
 
 Options:
-  --help show help
-  --dut  show dut list
+  -d, --dummy       dummy option
+  --help            show help
+  --dut             show dut list
 
 Commands:
   shibuya
@@ -36,6 +37,7 @@ Positional Arguments:
   tests             test name or pattern
 
 Options:
+  -d, --dummy       dummy option
   --help            display usage information
 EOF
   fi
@@ -56,6 +58,8 @@ test_complete
 echo "${COMPREPLY[@]}" | grep -wq "shibuya"
 echo "${COMPREPLY[@]}" | grep -wq "roppongi"
 echo "${COMPREPLY[@]}" | grep -wq "Commands" && exit 1
+echo "${COMPREPLY[@]}" | grep -wq -e "-d"
+echo "${COMPREPLY[@]}" | grep -wq -e "--dummy"
 
 COMP_CWORD=1
 COMP_WORDS=("cro3" "shi" "")
@@ -75,4 +79,7 @@ test_complete
 echo "${COMPREPLY[@]}" | grep -wq "dummy.Test.First"
 echo "${COMPREPLY[@]}" | grep -wq "dummy.Test.Second"
 echo "${COMPREPLY[@]}" | grep -wq "dummy.Third" && exit 1
+echo "${COMPREPLY[@]}" | grep -wq -e "-d"
+echo "${COMPREPLY[@]}" | grep -wq -e "--dummy"
+
 exit 0

--- a/src/cmd/cro3.bash
+++ b/src/cmd/cro3.bash
@@ -117,7 +117,13 @@ _cro3_get_options() { # current
     -*)
       # All options start with '-'.
       if [ ${otype} -eq 2 ]; then
-        _cro3_arg_used "${a}" || echo "${a}"
+        _a=${a%,}
+        _cro3_arg_used "${_a}" || echo "${_a}"
+        if [ ${_a} != ${a} ]; then
+          # if there are both short and long option, first option ends with ','
+          _a=`echo ${_b} | awk '{print $1}'`
+          _cro3_arg_used "${_a}" || echo "${_a}"
+        fi
       fi
       ;;
     *)


### PR DESCRIPTION
If an option parameter has short and long formats, those are connected with comma and space. e.g. "-v, --verbosity".
This checks the first format ends with ',' (and removes it). In that case, parses the 2nd word as an option.