### PR TITLE
Support `stable` as a cro3 sync target revision

### DIFF
--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -50,7 +50,7 @@ pub struct Args {
     reference: Option<String>,
 
     /// cros or android arc version to sync.
-    /// e.g. for chromeOS: 14899.0.0, tot (for development)
+    /// e.g. for chromeOS: 14899.0.0, tot, stable (for development)
     /// e.g. for arc: rvc, tm, master (which maps to master-arc-dev)
     #[argh(option)]
     version: String,
@@ -116,7 +116,7 @@ pub fn run(args: &Args) -> Result<()> {
 
 /// Extract a appropriate version name from a argument.
 fn extract_cros_version(version: &String) -> Result<String> {
-    if version == "tot" {
+    if version == "tot" || version == "stable" {
         Ok(version.clone())
     } else {
         Ok(lookup_full_version(version, "eve")?)


### PR DESCRIPTION
The current recommendation is using `stable` branch for development in the ChromiumOS repository. 
https://www.chromium.org/chromium-os/developer-library/guides/development/developer-guide/#sync-to-stable
Therefore, I add `stable` to the supported version formats for `cro3 sync --cros` command.

 I initially attempted to make `stable` the default branch for the command, as in #227, but I canceled.
My local testing indicates that the `repo init` command doesn't support using a version manifest with `stable`  specified as a manifest revision.
I was unable to find any document that explains about it.
