### PR TITLE
dut monitor: Support local port forwarding option

### DIFF
--- a/src/cmd/dut.rs
+++ b/src/cmd/dut.rs
@@ -182,8 +182,8 @@ fn run_dut_vnc(args: &ArgsVnc) -> Result<()> {
         error!("Failed to kill previous vnc instance: {e}")
     }
 
-    let mut child_kmsvnc = target.start_port_forwarding(vnc_port, 5900, "kmsvnc", None)?;
-    let mut child_novnc = target.start_port_forwarding(web_port, 6080, "novnc", None)?;
+    let mut child_kmsvnc = target.start_port_forwarding(vnc_port, 5900, "kmsvnc", &[])?;
+    let mut child_novnc = target.start_port_forwarding(web_port, 6080, "novnc", &[])?;
 
     warn!("To use VNC via web browser, please open:");
     warn!("  http://localhost:{web_port}/vnc.html");

--- a/src/cmd/dut.rs
+++ b/src/cmd/dut.rs
@@ -220,10 +220,9 @@ fn parse_fwport(fwport: &str, loport: u16) -> Result<PortForwarding> {
     } else if let Some(caps) = v6_re.captures(fwport) {
         (caps.get(1).unwrap().as_str(), caps.get(3).unwrap().as_str())
     } else {
-        bail!("Failed to parse {fwport}")
+        return Err(anyhow!("Failed to parse {fwport}"));
     };
-    let port_no: u16 = port_str.parse().expect("Invalid port number.");
-    PortForwarding::new(loport, addr, port_no)
+    PortForwarding::new(loport, addr, port_str.parse()?)
 }
 
 fn run_dut_monitor(args: &ArgsDutMonitor) -> Result<()> {

--- a/src/dut.rs
+++ b/src/dut.rs
@@ -32,6 +32,7 @@ use rand::thread_rng;
 use rayon::prelude::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+//use strum::additional_attributes;
 use tracing::error;
 use tracing::info;
 use url::Url;
@@ -82,6 +83,30 @@ lazy_static! {
 
 pub static SSH_CACHE: KvCache<SshInfo> = KvCache::new("ssh_cache");
 
+/// PortForwarding represents Local/Remote forwarding on ssh
+#[derive(Debug, Clone)]
+pub struct PortForwarding {
+    fwport: u16,
+    address: String,
+    port: u16,
+}
+impl PortForwarding {
+    pub fn new(fwport: u16, address: &str, port: u16) -> Result<Self> {
+        let pfw = PortForwarding {
+            fwport,
+            address: address.to_string(),
+            port,
+        };
+        Ok(pfw)
+    }
+    pub fn to_ssh_args(&self) -> Vec<String> {
+        vec![
+            "-L".to_string(),
+            format!("{}:{}:{}", self.fwport, self.address, self.port),
+        ]
+    }
+}
+
 /// MonitoredDut holds connection to a monitoring Dut
 #[derive(Debug)]
 pub struct MonitoredDut {
@@ -90,16 +115,37 @@ pub struct MonitoredDut {
     port: u16,
     child: Option<async_process::Child>,
     reconnecting: bool,
+    fwports: Vec<PortForwarding>,
 }
+
+fn spawn_ssh_process(
+    ssh: &SshInfo,
+    port: u16,
+    fwports: &[PortForwarding],
+) -> Result<async_process::Child> {
+    let opt_args: Vec<Vec<String>> = fwports.iter().map(|x| x.to_ssh_args()).collect();
+    let opt_args: Vec<String> = opt_args.concat();
+    let ref_args: Vec<&str> = opt_args.iter().map(|x| x.as_ref()).collect();
+
+    block_on(ssh.start_ssh_forwarding(
+        port,
+        match ref_args.len() > 1 {
+            true => Some(&ref_args),
+            false => None,
+        },
+    ))
+}
+
 impl MonitoredDut {
-    pub fn new(dut: &str, port: u16) -> Result<Self> {
+    pub fn new(dut: &str, port: u16, fwports: &[PortForwarding]) -> Result<Self> {
         let ssh = SshInfo::new(dut).context("failed to create SshInfo")?;
         let dut = MonitoredDut {
             ssh: ssh.clone(),
             dut: dut.to_string(),
             port,
-            child: block_on(ssh.start_ssh_forwarding(port)).ok(),
+            child: spawn_ssh_process(&ssh, port, fwports).ok(),
             reconnecting: false,
+            fwports: fwports.to_vec(),
         };
         Ok(dut)
     }
@@ -107,7 +153,7 @@ impl MonitoredDut {
         self.reconnecting
     }
     fn reconnect(&mut self) -> Result<String> {
-        let new_child = block_on(self.ssh.start_ssh_forwarding(self.port));
+        let new_child = spawn_ssh_process(&self.ssh, self.port, &self.fwports);
         if let Err(e) = &new_child {
             error!("Failed to reconnect: {e:?}");
         };
@@ -123,12 +169,20 @@ impl MonitoredDut {
             match child.try_status()? {
                 None => {
                     self.reconnecting = false;
-                    Ok(format!(
+                    let mut status = format!(
                         "{:<31}\t127.0.0.1:{:<5}\t{}",
                         &self.dut,
                         self.port,
                         &self.ssh.host_and_port()
-                    ))
+                    );
+                    self.fwports.iter().for_each(|fwp: &PortForwarding| {
+                        status += format!(
+                            "\n{:<31}\t127.0.0.1:{:<5}\t{}:{}",
+                            " +-", fwp.fwport, &fwp.address, fwp.port
+                        )
+                        .as_str()
+                    });
+                    Ok(status)
                 }
                 Some(_status) => self.reconnect(),
             }
@@ -627,18 +681,25 @@ impl SshInfo {
         port: u16,
         dut_port: u16,
         command: &str,
+        additional_ssh_args: Option<&Vec<&str>>,
     ) -> Result<async_process::Child> {
+        let fixed_args = [
+            "-L",
+            &format!("{}:127.0.0.1:{}", port, dut_port),
+            "-o",
+            "ExitOnForwardFailure yes",
+            "-o",
+            "ServerAliveInterval=5",
+            "-o",
+            "ServerAliveCountMax=1",
+        ];
+        let mut args: Vec<&str> = fixed_args.to_vec();
+        if let Some(opt_args) = additional_ssh_args {
+            args.extend(opt_args.iter());
+        }
+
         let child = self
-            .ssh_cmd_async(Some(&[
-                "-L",
-                &format!("{}:127.0.0.1:{}", port, dut_port),
-                "-o",
-                "ExitOnForwardFailure yes",
-                "-o",
-                "ServerAliveInterval=5",
-                "-o",
-                "ServerAliveCountMax=1",
-            ]))?
+            .ssh_cmd_async(Some(&args))?
             .arg(command)
             .kill_on_drop(true)
             .stdin(Stdio::piped())
@@ -649,11 +710,18 @@ impl SshInfo {
     }
     // Start SSH port forwarding on a given port.
     // The future will be resolved once the first connection attempt is succeeded.
-    pub async fn start_ssh_forwarding(&self, port: u16) -> Result<async_process::Child> {
-        self.start_ssh_forwarding_in_range(Range {
-            start: port,
-            end: port + 1,
-        })
+    pub async fn start_ssh_forwarding(
+        &self,
+        port: u16,
+        additional_ssh_args: Option<&Vec<&str>>,
+    ) -> Result<async_process::Child> {
+        self.start_ssh_forwarding_in_range(
+            Range {
+                start: port,
+                end: port + 1,
+            },
+            additional_ssh_args,
+        )
         .await
         .map(|e| e.0)
     }
@@ -661,6 +729,7 @@ impl SshInfo {
     async fn start_ssh_forwarding_in_range(
         &self,
         port_range: Range<u16>,
+        additional_ssh_args: Option<&Vec<&str>>,
     ) -> Result<(async_process::Child, u16)> {
         const COMMON_PORT_FORWARD_TOKEN: &str = "cro3-ssh-portforward";
         let sshcmd = &format!("echo {COMMON_PORT_FORWARD_TOKEN}; sleep 8h");
@@ -669,7 +738,7 @@ impl SshInfo {
         ports.shuffle(&mut rng);
         for port in ports {
             // Try to establish port forwarding
-            let mut child = self.start_port_forwarding(port, 22, sshcmd)?;
+            let mut child = self.start_port_forwarding(port, 22, sshcmd, additional_ssh_args)?;
             let (ssh_stdout, ssh_stderr) = get_async_lines(&mut child);
             let ssh_stdout = ssh_stdout.context(anyhow!("ssh_stdout was None"))?;
             let ssh_stderr = ssh_stderr.context(anyhow!("ssh_stderr was None"))?;
@@ -709,7 +778,7 @@ impl SshInfo {
     /// start_ssh_forwarding, and the same port will be used for reconnecting
     /// while this cro3 instance is running.
     fn start_ssh_forwarding_background_in_range(&self, port_range: Range<u16>) -> Result<u16> {
-        let (mut child, port) = block_on(self.start_ssh_forwarding_in_range(port_range))?;
+        let (mut child, port) = block_on(self.start_ssh_forwarding_in_range(port_range, None))?;
         let ssh = self.clone();
         thread::spawn(move || {
             block_on(async move {
@@ -718,7 +787,7 @@ impl SshInfo {
                     info!("cro3: SSH forwarding process exited with {status:?}");
                     loop {
                         info!("cro3: Reconnecting to {ssh:?}...");
-                        if let Ok(new_child) = ssh.start_ssh_forwarding(port).await {
+                        if let Ok(new_child) = ssh.start_ssh_forwarding(port, None).await {
                             child = new_child;
                             break;
                         }

--- a/src/dut.rs
+++ b/src/dut.rs
@@ -169,20 +169,23 @@ impl MonitoredDut {
             match child.try_status()? {
                 None => {
                     self.reconnecting = false;
-                    let mut status = format!(
+                    let status: String = format!(
                         "{:<31}\t127.0.0.1:{:<5}\t{}",
                         &self.dut,
                         self.port,
                         &self.ssh.host_and_port()
                     );
-                    self.fwports.iter().for_each(|fwp: &PortForwarding| {
-                        status += format!(
-                            "\n{:<31}\t127.0.0.1:{:<5}\t{}:{}",
-                            " +-", fwp.fwport, &fwp.address, fwp.port
-                        )
-                        .as_str()
-                    });
-                    Ok(status)
+                    let status2: Vec<String> = self
+                        .fwports
+                        .iter()
+                        .map(|fwp: &PortForwarding| {
+                            format!(
+                                "\n{:<31}\t127.0.0.1:{:<5}\t{}:{}",
+                                " +-", fwp.fwport, &fwp.address, fwp.port
+                            )
+                        })
+                        .collect();
+                    Ok(status + status2.join("").as_str())
                 }
                 Some(_status) => self.reconnect(),
             }


### PR DESCRIPTION
Add the options for local port forwarding for each DUT on `cro3 dut monitor`. This allows user to make DUT working as gateway. e.g.

cro3 dut monitor mydut,192.168.111.222:3456

This will map some local port to 192.168.111.222:3456 via mydut.